### PR TITLE
prep-3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Flagscript is available as a NuGet package:
 ### .NET CLI
 
 ```bash
-> dotnet add package Flagscript --version 3.1.1
+> dotnet add package Flagscript --version 3.2.0
 ```
 
 ### .csproj
 
 ```xml
-<PackageReference Include="Flagscript" Version="3.1.1" />
+<PackageReference Include="Flagscript" Version="3.2.0" />
 ```
 
 ## Contributing

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 #---------------------------------#
 
 # version format
-version: '3.1.1.{build}'
+version: '3.2.0.{build}'
 
 # Maximum number of concurrent jobs for the project
 max_jobs: 1
@@ -25,7 +25,7 @@ clone_depth: 1
 
 #environment variables
 environment:
-  use_version: 3.1.1
+  use_version: 3.2.0
 
 # scripts that run after cloning repository
 install:

--- a/src/Flagscript/Flagscript.csproj
+++ b/src/Flagscript/Flagscript.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackOnBuild>false</PackOnBuild>
-    <PackageVersion>3.1.1</PackageVersion>
+    <PackageVersion>3.2.0</PackageVersion>
     <Authors>Greg Kaestle, Flagscript</Authors>
     <Company>Flagscript</Company>
     <Copyright>©2019 Flagscript</Copyright>
@@ -14,14 +14,14 @@
     <RepositoryType>git</RepositoryType>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Owners>Greg Kaestle, Flagscript</Owners>
-    <PackageProjectUrl>https://github.com/flagscript/Flagscript/projects/2</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/flagscript/Flagscript/projects/3</PackageProjectUrl>
     <PackageReleaseNotes>Fix NuGet metadata and Codacy style errors</PackageReleaseNotes>
     <Summary>Foundational Classes for the Flagscript Framework</Summary>
     <PackageTags>dotnet, dotnet-standard, dotnet-library, flagscript</PackageTags>
     <Description>Foundational Classes for the Flagscript Framework</Description>
-    <AssemblyVersion>3.1.1</AssemblyVersion>
-    <FileVersion>3.1.1</FileVersion>
-    <InformationalVersion>3.1.1</InformationalVersion>
+    <AssemblyVersion>3.2.0</AssemblyVersion>
+    <FileVersion>3.2.0</FileVersion>
+    <InformationalVersion>3.2.0</InformationalVersion>
     <PackageId>Flagscript</PackageId>
     <Product>Flagscript</Product>
   </PropertyGroup>  

--- a/src/Flagscript/Flagscript.csproj
+++ b/src/Flagscript/Flagscript.csproj
@@ -15,7 +15,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <Owners>Greg Kaestle, Flagscript</Owners>
     <PackageProjectUrl>https://github.com/flagscript/Flagscript/projects/3</PackageProjectUrl>
-    <PackageReleaseNotes>Fix NuGet metadata and Codacy style errors</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/flagscript/Flagscript.Gravatar/blob/master/CHANGELOG.md</PackageReleaseNotes>
     <Summary>Foundational Classes for the Flagscript Framework</Summary>
     <PackageTags>dotnet, dotnet-standard, dotnet-library, flagscript</PackageTags>
     <Description>Foundational Classes for the Flagscript Framework</Description>


### PR DESCRIPTION
**Other**

- Bump Build and Project files to 3.2.0
- Reset Appveyor Build Number

**Issues**

- Resolves #28: Update build/project files for 3.2.0